### PR TITLE
Adjust test_writer_bad_message for ujson

### DIFF
--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -120,9 +120,9 @@ def test_writer_bad_message(wfile, writer):
         b'Content-Length: 10\r\n'
         b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
         b'\r\n'
-        b'1546304461',
+        b'1546300861',
         b'Content-Length: 10\r\n'
         b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
         b'\r\n'
-        b'1546322461'
+        b'1546300861'
     ]


### PR DESCRIPTION
The correct timestamp value of
`datetime.datetime(2019, 1, 1, 1, 1,1).timestamp()` is 1546300861.

Closes: #6