### PR TITLE
Use f-strings wherever possible

### DIFF
--- a/pylsp_jsonrpc/dispatchers.py
+++ b/pylsp_jsonrpc/dispatchers.py
@@ -16,7 +16,7 @@ class MethodDispatcher:
     """
 
     def __getitem__(self, item):
-        method_name = 'm_{}'.format(_method_to_string(item))
+        method_name = f'm_{_method_to_string(item)}'
         if hasattr(self, method_name):
             method = getattr(self, method_name)
 

--- a/pylsp_jsonrpc/streams.py
+++ b/pylsp_jsonrpc/streams.py
@@ -74,7 +74,7 @@ class JsonRpcStreamReader:
             try:
                 return int(value)
             except ValueError as e:
-                raise ValueError("Invalid Content-Length header: {}".format(value)) from e
+                raise ValueError(f"Invalid Content-Length header: {value}") from e
 
         return None
 
@@ -100,9 +100,9 @@ class JsonRpcStreamWriter:
                 content_length = len(body) if isinstance(body, bytes) else len(body.encode('utf-8'))
 
                 response = (
-                    "Content-Length: {}\r\n"
-                    "Content-Type: application/vscode-jsonrpc; charset=utf8\r\n\r\n"
-                    "{}".format(content_length, body)
+                    f"Content-Length: {content_length}\r\n"
+                    f"Content-Type: application/vscode-jsonrpc; charset=utf8\r\n\r\n"
+                    f"{body}"
                 )
 
                 self._wfile.write(response.encode('utf-8'))

--- a/test/test_endpoint.py
+++ b/test/test_endpoint.py
@@ -332,7 +332,7 @@ def assert_consumer_error(consumer_mock, exception):
 
 def await_assertion(condition, timeout=3.0, interval=0.1, exc=None):
     if timeout <= 0:
-        raise exc if exc else AssertionError("Failed to wait for condition %s" % condition)
+        raise exc if exc else AssertionError(f"Failed to wait for condition {condition}")
     try:
         condition()
     except AssertionError as e:

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -98,7 +98,7 @@ class JsonDatetime(datetime.datetime):
             dif = int(self.timestamp())
         else:
             dif = int((self - datetime.datetime(1970, 1, 1)).total_seconds())
-        return '{0}'.format(dif)
+        return f'{dif}'
 
 
 def test_writer_bad_message(wfile, writer):


### PR DESCRIPTION
This fixes the errors reported by Pylint when analyzing our codebase.