### PR TITLE
Drop Python 3.6 on CIs and start testing with Python 3.10

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           # TODO: check with Python 3, but need to fix the
           # errors first
-          python-version: '3.6'
+          python-version: '3.8'
           architecture: 'x64'
       - run: python -m pip install --upgrade pip setuptools
       - run: pip install -e .[test]

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.8', '3.7', '3.6']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8', '3.7']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.8', '3.7', '3.6']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8', '3.7']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.8', '3.7', '3.6']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8', '3.7']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1


### PR DESCRIPTION
That version reached end-of-life in December, so we don't need to test against it anymore.