### PR TITLE
Make necessary changes to drop support for Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python JSON RPC Server
 
-A Python 3.6+ server implementation of the [JSON RPC 2.0](http://www.jsonrpc.org/specification) protocol. This library has been pulled out of the [Python LSP Server](https://github.com/python-lsp/python-lsp-server) project.
+A Python 3.7+ server implementation of the [JSON RPC 2.0](http://www.jsonrpc.org/specification) protocol. This library has been pulled out of the [Python LSP Server](https://github.com/python-lsp/python-lsp-server) project.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ build-backend = "setuptools.build_meta"
 name = "python-lsp-jsonrpc"
 authors = [{name = "Python Language Server Contributors"}]
 description = "JSON RPC 2.0 server library"
+license = {text = "MIT"}
+requires-python = ">=3.7"
 dependencies = ["ujson>=3.0.0"]
 dynamic = ["version"]
 
@@ -30,6 +32,7 @@ test = [
 ]
 
 [tool.setuptools]
+license-files = ["LICENSE"]
 include-package-data = false
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Also, add license info to `pyproject.toml`.

Fixes #11.