### PR TITLE
Add license trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ license = {text = "MIT"}
 requires-python = ">=3.7"
 dependencies = ["ujson>=3.0.0"]
 dynamic = ["version"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
Tools like [`pip-licenses`](https://pypi.org/project/pip-licenses/) scrape this.

Fixes https://github.com/python-lsp/python-lsp-jsonrpc/issues/18