### PR TITLE
Allow method handlers to return json rpc errors

### DIFF
--- a/pylsp_jsonrpc/endpoint.py
+++ b/pylsp_jsonrpc/endpoint.py
@@ -195,11 +195,17 @@ class Endpoint:
             handler_result.add_done_callback(self._request_callback(msg_id))
         else:
             log.debug("Got result from synchronous request handler: %s", handler_result)
-            self._consumer({
+            response = {
                 'jsonrpc': JSONRPC_VERSION,
                 'id': msg_id,
-                'result': handler_result
-            })
+            }
+            if 'result' in handler_result:
+                response['result'] = handler_result['result']
+            if 'error' in handler_result:
+                response['error'] = handler_result['error']
+            if 'result' not in handler_result and 'error' not in handler_result:
+                response['result'] = handler_result
+            self._consumer(response)
 
     def _request_callback(self, request_id):
         """Construct a request callback for the given request ID."""
@@ -216,7 +222,13 @@ class Endpoint:
             }
 
             try:
-                message['result'] = future.result()
+                result = future.result()
+                if 'result' in result:
+                    message['result'] = result['result']
+                if 'error' in result:
+                    message['error'] = result['error']
+                if 'result' not in result and 'error' not in result:
+                    message['result'] = result
             except JsonRpcException as e:
                 log.exception("Failed to handle request %s", request_id)
                 message['error'] = e.to_dict()

--- a/pylsp_jsonrpc/endpoint.py
+++ b/pylsp_jsonrpc/endpoint.py
@@ -177,13 +177,11 @@ class Endpoint:
             log.debug("Cancelled request with id %s", msg_id)
 
     @staticmethod
-    def _make_response_payload(
-        header: Dict[str, Any], result: Dict[str, Any]
-    ) -> Mapping[str, Any]:
+    def _make_response_payload(header: Dict[str, Any], result: Any) -> Mapping[str, Any]:
         # return type of 'Mapping' because it should not be mutated
         # further from here
         response = dict(header)
-        if 'result' in result or 'error' in result:
+        if isinstance(result, dict) and ('result' in result or 'error' in result):
             response.update(result)
         else:
             response['result'] = result


### PR DESCRIPTION
In this PR, we allow method handlers to return results that could themselves contain "result" and "error" fields. If they contain neither field, the old behavior is maintained. If they contain one or both fields, however, we read those fields and use them in the json rpc response.

This will be useful for addressing https://github.com/python-lsp/python-lsp-server/issues/314 -- rather than raising an exception when we get a request post-shutdown, we'll be able to instead call a method that returns a json rpc invalid request.

See also https://github.com/python-lsp/python-lsp-server/pull/432