### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.10', '3.9', '3.8', '3.7']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.10', '3.9', '3.8', '3.7']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.10', '3.9', '3.8', '3.7']
+        PYTHON_VERSION: ['3.10', '3.9', '3.8']
     timeout-minutes: 10
     steps:
       - uses: actions/cache@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python JSON RPC Server
 
-A Python 3.7+ server implementation of the [JSON RPC 2.0](http://www.jsonrpc.org/specification) protocol. This library has been pulled out of the [Python LSP Server](https://github.com/python-lsp/python-lsp-server) project.
+A Python 3.8+ server implementation of the [JSON RPC 2.0](http://www.jsonrpc.org/specification) protocol. This library has been pulled out of the [Python LSP Server](https://github.com/python-lsp/python-lsp-server) project.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "python-lsp-jsonrpc"
 authors = [{name = "Python Language Server Contributors"}]
 description = "JSON RPC 2.0 server library"
 license = {text = "MIT"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = ["ujson>=3.0.0"]
 dynamic = ["version"]
 


### PR DESCRIPTION
That version reached end-of-life last June, so there's no need for us to support it anymore.