### PR TITLE
Fix tests so they're compatible with both ujson and pure json library

### DIFF
--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -82,13 +82,20 @@ def test_writer(wfile, writer):
         'method': 'method',
         'params': {}
     })
-
-    assert wfile.getvalue() == (
-        b'Content-Length: 44\r\n'
-        b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
-        b'\r\n'
-        b'{"id":"hello","method":"method","params":{}}'
-    )
+    if 'ujson' in sys.modules:
+        assert wfile.getvalue() == (
+            b'Content-Length: 44\r\n'
+            b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
+            b'\r\n'
+            b'{"id":"hello","method":"method","params":{}}'
+        )
+    else:
+        assert wfile.getvalue() == (
+            b'Content-Length: 49\r\n'
+            b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
+            b'\r\n'
+            b'{"id": "hello", "method": "method", "params": {}}'
+        )
 
 
 class JsonDatetime(datetime.datetime):


### PR DESCRIPTION
The built-in `json` library adds spacing to json output that `ujson` does not add. Consequently, the `test_writer` method in `test/test_streams.py` fails when using `json` as written. This PR simply modifies the test so that the appropriate return value is used based on which json library has been imported. 