### PR TITLE
Replace ujson with orjson

### DIFF
--- a/examples/langserver.py
+++ b/examples/langserver.py
@@ -5,8 +5,8 @@ from tornado import web, ioloop, websocket
 from pylsp_jsonrpc import dispatchers, endpoint
 
 try:
-    import ujson as json
-except Exception:  # pylint: disable=broad-except
+    import orjson as json
+except ImportError:
     import json
 
 log = logging.getLogger(__name__)

--- a/examples/langserver_ext.py
+++ b/examples/langserver_ext.py
@@ -7,8 +7,8 @@ from tornado import ioloop, process, web, websocket
 from pylsp_jsonrpc import streams
 
 try:
-    import ujson as json
-except Exception:  # pylint: disable=broad-except
+    import orjson as json
+except ImportError:
     import json
 
 log = logging.getLogger(__name__)

--- a/pylsp_jsonrpc/streams.py
+++ b/pylsp_jsonrpc/streams.py
@@ -5,8 +5,8 @@ import logging
 import threading
 
 try:
-    import ujson as json
-except Exception:  # pylint: disable=broad-except
+    import orjson as json
+except ImportError:
     import json
 
 log = logging.getLogger(__name__)

--- a/pylsp_jsonrpc/streams.py
+++ b/pylsp_jsonrpc/streams.py
@@ -86,8 +86,9 @@ class JsonRpcStreamWriter:
         self._wfile_lock = threading.Lock()
 
         if 'orjson' in sys.modules and json_dumps_args.pop('sort_keys'):
-            # orjson needs different option handling
-            self._json_dumps_args = {'option': json.OPT_SORT_KEYS}
+            # orjson needs different option handling;
+            # pylint has an erroneous error here https://github.com/pylint-dev/pylint/issues/9762
+            self._json_dumps_args = {'option': json.OPT_SORT_KEYS} # pylint: disable=maybe-no-member
             self._json_dumps_args.update(**json_dumps_args)
         else:
             self._json_dumps_args = json_dumps_args

--- a/pylsp_jsonrpc/streams.py
+++ b/pylsp_jsonrpc/streams.py
@@ -88,7 +88,7 @@ class JsonRpcStreamWriter:
         if 'orjson' in sys.modules and json_dumps_args.pop('sort_keys'):
             # orjson needs different option handling;
             # pylint has an erroneous error here https://github.com/pylint-dev/pylint/issues/9762
-            self._json_dumps_args = {'option': json.OPT_SORT_KEYS} # pylint: disable=maybe-no-member
+            self._json_dumps_args = {'option': json.OPT_SORT_KEYS}  # pylint: disable=maybe-no-member
             self._json_dumps_args.update(**json_dumps_args)
         else:
             self._json_dumps_args = json_dumps_args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{name = "Python Language Server Contributors"}]
 description = "JSON RPC 2.0 server library"
 license = {text = "MIT"}
 requires-python = ">=3.8"
-dependencies = ["ujson>=3.0.0"]
+dependencies = ["orjson>=3.10.0"]
 dynamic = ["version"]
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -77,25 +77,20 @@ def test_reader_bad_json(rfile, reader):
 
 
 def test_writer(wfile, writer):
-    writer.write({
+    data = {
         'id': 'hello',
         'method': 'method',
         'params': {}
-    })
-    if 'ujson' in sys.modules:
-        assert wfile.getvalue() == (
-            b'Content-Length: 44\r\n'
-            b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
-            b'\r\n'
-            b'{"id":"hello","method":"method","params":{}}'
-        )
-    else:
-        assert wfile.getvalue() == (
-            b'Content-Length: 49\r\n'
-            b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
-            b'\r\n'
-            b'{"id": "hello", "method": "method", "params": {}}'
-        )
+    }
+    writer.write(data)
+
+    raw_result = wfile.getvalue().decode()
+    raw_result_lines = raw_result.split()
+
+    assert raw_result_lines[0].split(":") == "Content-Length"
+    assert raw_result_lines[1] == 'Content-Type: application/vscode-jsonrpc; charset=utf8'
+    assert raw_result_lines[2] == ''
+    assert json.loads(raw_result_lines[3]) == data
 
 
 class JsonDatetime(datetime.datetime):

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -7,8 +7,8 @@ from io import BytesIO
 import datetime
 import sys
 from unittest import mock
-import pytest
 import json
+import pytest
 
 from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
 

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -92,7 +92,7 @@ def test_writer(wfile, writer):
     )
 
 
-def test_writer_builtin_json(wfile):
+def test_writer_stdlib_json(wfile):
     """Test the stream writer using the standard json lib."""
     data = {
         'id': 'hello',

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -32,6 +32,7 @@ def reader(rfile):
 def writer(wfile):
     return JsonRpcStreamWriter(wfile, sort_keys=True)
 
+
 def test_reader(rfile, reader):
     rfile.write(
         b'Content-Length: 49\r\n'


### PR DESCRIPTION
This PR is an attempt to carry https://github.com/python-lsp/python-lsp-jsonrpc/pull/28 to completion, making the necessary changes to ensure compatibility with `orjson` and adding tests against both `orjson` and the stdlib `json` to ensure that the writer works no matter which is imported.

There were two main pieces necessary for the migration:
1. `orjson` doesn't support the `sort_keys` kwarg to `dumps`; instead its `dumps` takes an `option` kwarg which expects bitwise flags. This PR makes the necessary changes to `self._json_dumps_args` in `JsonRpcStreamWriter.__init__` depending on whether `orjson` is available. (Unnecessary but hopefully helpful: it also adds the `separators=(',', ':')` kwarg to the stdlib json case so that it matches `orjson`'s behavior of omitting unnecessary spaces.)
2. `orjson.dumps` returns bytes, not a string. This PR encodes the dumped JSON if necessary (i.e. in the stdlib case) and uses [bytestring % formatting](https://peps.python.org/pep-0461/) to populate `response` in `JsonRpcStreamWriter.write`.

It was tricky to make sure that this worked with or without `orjson`. The existing test only tests the `orjson` case if `orjson` is available on the system on which the tests are run, but I wanted to be sure to test `JsonRpcStreamWriter` against the stdlib `json` too. As such, this PR adds a `test_writer_stdlib_json` test that uses some funky patching to ensure that `JsonRpcStreamWriter.write` behaves correctly when `orjson` is unavailable. It's a bit hacky but I confirmed that it does what's intended in the debugger and it seemed better than risking a developer breaking the writer for users who can't import `orjson`. (Unfortunately I don't think there's any good way to test the writer against `orjson` if it can't be imported in the dev's environment!)